### PR TITLE
Fix: Empty lines in requirements.txt breaks dependency parsing

### DIFF
--- a/scurvysin/__init__.py
+++ b/scurvysin/__init__.py
@@ -96,7 +96,7 @@ def parse_requirements_file(path: str) -> List[str]:
             line = line.strip()
             if line.startswith("-"):
                 raise NotImplementedError("Pip flags in requirements files are not understood.")
-            elif line.startswith("#"):
+            elif not line or line.startswith("#"):
                 continue
             else:
                 reqs.append(line)


### PR DESCRIPTION
Empty line got parsed as "empty string" dependency which could not be interpreted by pkg_resources parser.

The fix just ignores empty lines.